### PR TITLE
Feature/permission

### DIFF
--- a/adapters/repositories.py
+++ b/adapters/repositories.py
@@ -55,6 +55,12 @@ class AbstractCollaboratorRepository(AbstractRepository):
         raise NotImplementedError
 
 
+class AbstractContractRepository(AbstractRepository):
+    @abstractmethod
+    def get_client_from_contract(self, contract_id):
+        raise NotImplementedError
+
+
 class SqlAlchemyRepository(AbstractRepository):
     model_cls = None
 
@@ -83,14 +89,16 @@ class SqlAlchemyUserRepository(SqlAlchemyRepository, AbstractUserRepository):
     model_cls = AuthUser
 
     def get_by_username(self, username):
-        return self.session.query(self.model_cls).filter_by(username=username).one_or_none()
+        return self.session.query(self.model_cls).filter_by(
+            username=username).one_or_none()
 
 
 class SqlAlchemyRoleRepository(SqlAlchemyRepository):
     model_cls = Role
 
 
-class SqlAlchemyCollaboratorRepository(SqlAlchemyRepository):
+class SqlAlchemyCollaboratorRepository(SqlAlchemyRepository,
+                                       AbstractCollaboratorRepository):
     model_cls = Collaborator
 
     def get_by_user_id(self, user_id):
@@ -102,8 +110,14 @@ class SqlAlchemyClientRepository(SqlAlchemyRepository):
     model_cls = Client
 
 
-class SqlAlchemyContractRepository(SqlAlchemyRepository):
+class SqlAlchemyContractRepository(SqlAlchemyRepository,
+                                   AbstractContractRepository):
     model_cls = Contract
+
+    def get_client_from_contract(self, contract_id):
+        contract = self._get(contract_id)
+        return self.session.query(Client).filter_by(
+            id=contract.client_id).one_or_none()
 
 
 class SqlAlchemyEventRepository(SqlAlchemyRepository):

--- a/controllers/permission.py
+++ b/controllers/permission.py
@@ -1,0 +1,143 @@
+from controllers.login import check_token
+from functools import wraps
+from inspect import signature, Parameter
+
+
+def is_authenticated():
+    payload = check_token()
+    if payload is None:
+        raise PermissionError('Authentication invalid')
+    return payload
+
+
+def is_management(ctx):
+    return ctx['auth']['role'] == 3
+
+
+def is_sales(ctx):
+    return ctx['auth']['role'] == 4
+
+
+def is_support(ctx):
+    return ctx['auth']['role'] == 5
+
+
+# Implement later, uow should be in services layer
+
+# def is_client_salesman(ctx):
+#     uow = ctx['uow']
+#     return (uow.clients.get(ctx['client_id']).salesman_id ==
+#             ctx['auth']['c_id'])
+#
+#
+# def is_contract_salesman(ctx):
+#     uow = ctx['uow']
+#     return uow.contracts.get_client_from_contract(ctx['contract_id']).salesman_id == ctx['auth']['c_id']
+#
+#
+# def is_event_support(ctx):
+#     uow = ctx['uow']
+#     return uow.events.get(ctx['event_id']).support_id == ctx['auth']['c_id']
+
+
+def _map_func_signature_and_value(func, *args, **kwargs):
+    # source : https://www.geeksforgeeks.org/python-get-function-signature/
+    ctx = {}
+    # get func positional args name
+    arg_names = func.__code__.co_varnames[:func.__code__.co_argcount]
+
+    # map func args name with values (not defaults one)
+    # map the rest of args in a 'args' keyword
+    args_dict = dict(zip(arg_names, args))
+    args_dict['args'] = args[len(arg_names):]
+
+    # map the defaults values of positional args if not given
+    defaults_args_value = func.__defaults__
+    if defaults_args_value:
+        defaults_arg_names = dict(zip(arg_names, defaults_args_value))
+        for name, default in defaults_arg_names.items():
+            args_dict.setdefault(name, default)
+
+    ctx.update(args_dict)
+
+    # map the keyword arguments if not given
+    for key, default in (func.__kwdefaults__ or {}).items():
+        kwargs.setdefault(key, default)
+
+    ctx.update(kwargs)
+
+    return ctx
+
+
+def _verify_requirements(ctx, requirements):
+    for group in requirements:
+        if not any(rule(ctx) for rule in group):
+            raise PermissionError(
+                f'Permission error in {[perm.__name__ for perm in group]}')
+
+
+def _accept_kwargs(func):
+    # https://docs.python.org/3/library/inspect.html#inspect.Parameter.kind
+    sig = signature(func)
+    return any(p.kind == Parameter.VAR_KEYWORD for
+               p in sig.parameters.values())
+
+
+def permission(_func=None, *, requirements=None, kw_auth=True):
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            auth = is_authenticated()
+            ctx = {'auth': auth}
+
+            if requirements:
+                ctx.update(
+                    _map_func_signature_and_value(func, *args, **kwargs))
+
+                _verify_requirements(ctx, requirements)
+
+            # if flag is raised and func accept **kwargs can pass payload
+            if kw_auth and _accept_kwargs(func):
+                kwargs['auth'] = auth
+
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if _func is None:
+        return decorator
+    else:
+        return decorator(_func)
+
+
+# def authenticated(func):
+#     @wraps(func)
+#     def wrapper(*args, **kwargs):
+#         payload = is_authenticated()
+#         if payload is None:
+#             raise (Exception('Need authentication'))
+#         kwargs['auth'] = payload
+#         return func(*args, **kwargs)
+#
+#     return wrapper
+#
+#
+# def old_permission(requirements):
+#     def decorator(func):
+#         @wraps(func)
+#         def wrapper(*args, **kwargs):
+#
+#             for group in requirements:
+#                 if not any(rule(kwargs) for rule in group):
+#                     raise Exception(
+#                         f'Permission error in {
+#                           [perm.__name__ for perm in group]}')
+#             # kwargs cleanup
+#             for key in perms_key:
+#                 kwargs.pop(key, None)
+#             return func(*args, **kwargs)
+#
+#         return wrapper
+#
+#     return decorator

--- a/services/unit_of_work.py
+++ b/services/unit_of_work.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.session import Session
 
 from config import get_postgres_uri
 from adapters import repositories as repo
@@ -13,7 +12,7 @@ class AbstractUnitOfWork(ABC):
     roles: repo.AbstractRepository
     collaborators: repo.AbstractCollaboratorRepository
     clients: repo.AbstractRepository
-    contracts: repo.AbstractRepository
+    contracts: repo.AbstractContractRepository
     events: repo.AbstractRepository
 
     def __enter__(self):

--- a/tests/test_controller/test_permission.py
+++ b/tests/test_controller/test_permission.py
@@ -1,0 +1,141 @@
+import pytest
+
+from controllers import permission as p
+
+
+def valid_management_payload():
+    return {
+        'sub': 'user_01',
+        'c_id': 1,
+        'role': 3,
+        'name': 'Charmion Garthland',
+        'iat': 1748116252,
+        'exp': 1748116342
+    }
+
+
+def valid_sales_payload():
+    return {
+        'sub': 'user_01',
+        'c_id': 1,
+        'role': 4,
+        'name': 'Charmion Garthland',
+        'iat': 1748116252,
+        'exp': 1748116342
+    }
+
+
+def valid_support_payload():
+    return {
+        'sub': 'user_01',
+        'c_id': 1,
+        'role': 5,
+        'name': 'Charmion Garthland',
+        'iat': 1748116252,
+        'exp': 1748116342
+    }
+
+
+@pytest.mark.parametrize(
+    'payload',
+    [
+        valid_management_payload(),
+        valid_sales_payload(),
+        valid_support_payload(),
+    ]
+)
+def test_is_authenticated_success(mocker, payload):
+    mocker.patch('controllers.permission.check_token',
+                 return_value=payload)
+    assert p.is_authenticated()['c_id'] == 1
+
+
+def test_is_authenticated_failure(mocker):
+    mocker.patch('controllers.permission.check_token',
+                 return_value=None)
+    with pytest.raises(PermissionError, match="Authentication invalid"):
+        p.is_authenticated()
+
+
+def test_permission_with_bad_authenticated(mocker):
+    mocker.patch('controllers.permission.check_token',
+                 return_value=None)
+
+    @p.permission
+    def test_func():
+        pass
+
+    with pytest.raises(PermissionError, match="Authentication invalid"):
+        test_func()
+
+
+def test_permission_with_kwargs_get_payload(mocker):
+    mocker.patch("controllers.permission.is_authenticated",
+                 return_value=valid_management_payload())
+
+    @p.permission
+    def test_func(**kwargs):
+        assert kwargs['auth']['c_id'] == 1
+        assert kwargs['auth']['role'] == 3
+
+    test_func()
+
+
+def test_permission_without_kwargs_dont_get_payload(mocker):
+    mocker.patch("controllers.permission.is_authenticated",
+                 return_value=valid_management_payload())
+
+    @p.permission
+    def test_func():
+        pass
+
+    test_func()
+
+
+def test_permission_with_kwargs_kw_auth_false_dont_get_payload(mocker):
+    mocker.patch("controllers.permission.is_authenticated",
+                 return_value=valid_management_payload())
+
+    @p.permission(kw_auth=False)
+    def test_func(**kwargs):
+        with pytest.raises(KeyError):
+            assert kwargs['auth']['c_id'] == 1
+            assert kwargs['auth']['role'] == 3
+
+    test_func()
+
+
+def test_permission_is_manager(mocker):
+    mocker.patch("controllers.permission.is_authenticated",
+                 return_value=valid_management_payload())
+
+    @p.permission(requirements=[(p.is_management,)])
+    def test_func(**kwargs):
+        assert kwargs['auth']['c_id'] == 1
+        assert kwargs['auth']['role'] == 3
+
+    test_func(keyword='keyword')
+
+
+def test_permission_is_manager_or_is_sales(mocker):
+    mocker.patch("controllers.permission.is_authenticated",
+                 return_value=valid_management_payload())
+
+    @p.permission(requirements=[(p.is_management, p.is_sales)])
+    def test_func(**kwargs):
+        assert kwargs['auth']['c_id'] == 1
+        assert kwargs['auth']['role'] == 3
+
+    test_func(keyword='keyword')
+
+
+def test_permission_is_manager_and_is_sales_raise_error(mocker):
+    mocker.patch("controllers.permission.is_authenticated",
+                 return_value=valid_management_payload())
+
+    @p.permission(requirements=[(p.is_management,), (p.is_sales,)])
+    def test_func(**kwargs):
+        pass
+
+    with pytest.raises(PermissionError):
+        test_func(keyword='keyword')


### PR DESCRIPTION
side fix:
+ Forgotten heritage in implementation of Collaborator and Contract repo
+ new method in Contract repo

feature:
+ New permission decorator
+ by default @permission check if user is authenticated (token is present and valid).
+ two optional keyword (requirements and kw_auth)
+ kw_auth allows the func to get the payload of tokens if **kwargs is in its signature.
+ requirements hold the logic for combination of permissions needed. this list of tuple combine each elements with a AND logic. Inside the tuples elements combine as OR, no implementation of NOT logic.

note:
+ implementation of permissions may be needed later but should be easily added.
+ a huge chunk of the code for the decorator might be refactored with a better use of the module inspect.